### PR TITLE
Add postinstall script for npm link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "renew-js",
+  "version": "0.1.0",
+  "scripts": {
+    "postinstall": "node ./scripts/postinstall.js"
+  }
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const resolve = require('path').resolve;
+const join = require('path').join;
+const cp = require('child_process');
+const os = require('os');
+
+const dir = resolve('.');
+const cmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm';
+const modules = [];
+
+fs.readdirSync(dir).forEach((module) => {
+    const cwd = join(dir, module);
+
+    if (fs.existsSync(join(cwd, 'package.json'))) {
+        modules.push(module);
+    }
+});
+
+modules.forEach((parent) => {
+    const cwd = join(dir, parent);
+
+    modules.forEach((child) => {
+        if (fs.existsSync(join(cwd, 'node_modules/' + child))) {
+            cp.spawn(cmd, [ 'link', '../' + child ], {
+                env: process.env,
+                cwd: cwd,
+                stdio: 'inherit'
+            });
+        }
+    });
+});


### PR DESCRIPTION
Closes #3 #4 

## Changes 
- Figured out that [`npm link`][1] is doing exaclty what we need
- Added a postinstall script that links all projects

[1]: https://docs.npmjs.com/cli/link.html