### PR TITLE
Add a serve script shortcut in renew-js to not switch directories after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "repository": "https://github.com/renew-js/renew-js",
   "scripts": {
+    "serve": "npm run serve --prefix ./renew-ui",
     "clean": "node ./scripts/clean.js",
     "postinstall": "node ./scripts/postinstall.js",
     "preinstall": "node ./scripts/preinstall.js",


### PR DESCRIPTION
Closes 25

## Describe your changes
- Add a serve script shortcut in renew-js to not switch directories after `npm install`

